### PR TITLE
Fix some memory leak issue in IE and in modern browsers

### DIFF
--- a/js/render/line_atlas.js
+++ b/js/render/line_atlas.js
@@ -143,3 +143,7 @@ LineAtlas.prototype.bind = function(gl) {
         }
     }
 };
+
+LineAtlas.prototype.remove = function() {
+    util.removeObjectProperties(this);
+};

--- a/js/render/painter.js
+++ b/js/render/painter.js
@@ -492,3 +492,7 @@ Painter.prototype.showOverdrawInspector = function(enabled) {
         gl.blendFunc(gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
     }
 };
+
+Painter.prototype.remove = function () {
+    util.removeObjectProperties(this);
+};

--- a/js/slv/point_group.js
+++ b/js/slv/point_group.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var util = require('../util/util');
+
 module.exports = PointGroup;
 
 function PointGroup(customBufferManager, quadrant) {
@@ -125,4 +127,8 @@ PointGroup.prototype.removeMarker = function (marker) {
         this.needsRefresh = true;
         this.rebuild();
     }
+};
+
+PointGroup.prototype.remove = function () {
+    util.removeObjectProperties(this);
 };

--- a/js/slv/quadrant.js
+++ b/js/slv/quadrant.js
@@ -30,7 +30,7 @@ Quadrant.findQuadrant = function (lng, lat, incX, incY) {
     else if (lng < -180) {
         lng += 360;
     }
-    
+
     return {
         col: Math.floor((lng + 180) / incX),
         row: Math.floor((90 - lat) / incY)
@@ -154,3 +154,8 @@ Quadrant.prototype.rebuildDepthSprites = function() {
     }
 };
 
+Quadrant.prototype.remove = function () {
+    this.staticGroups.forEach(function (staticGroup) {
+        staticGroup.remove();
+    });
+};

--- a/js/slv/quadrant_factory.js
+++ b/js/slv/quadrant_factory.js
@@ -20,3 +20,9 @@ QuadrantFactory.prototype.createQuadrant = function (row, col) {
 QuadrantFactory.prototype.getQuadrant = function (id) {
     return this.quadrants[id];
 };
+
+QuadrantFactory.prototype.remove = function () {
+    this.quadrants.forEach(function (quadrant) {
+        quadrant.remove();
+    });
+};

--- a/js/style/image_sprite.js
+++ b/js/style/image_sprite.js
@@ -1,5 +1,5 @@
 'use strict';
-
+var util = require('../util/util');
 var Evented = require('../util/evented');
 var ajax = require('../util/ajax');
 var browser = require('../util/browser');
@@ -76,4 +76,12 @@ ImageSprite.prototype.getSpritePosition = function(name) {
     if (pos && this.img) return pos;
 
     return new SpritePosition();
+};
+
+ImageSprite.prototype.remove = function() {
+    delete this.img.data.buffer;
+
+    util.removeObjectProperties(this.img);
+    util.removeObjectProperties(this.data);
+    util.removeObjectProperties(this);
 };

--- a/js/style/style.js
+++ b/js/style/style.js
@@ -681,6 +681,15 @@ Style.prototype = util.inherit(Evented, {
         }, callback);
     },
 
+    removeSources: function () {
+        util.removeObjectProperties(this.sources);
+        util.removeObjectProperties(this._updates.sources);
+
+        this.sprite.remove();
+        this.spriteAtlas.remove();
+        this.lineAtlas.remove();
+    },
+
     _handleErrors: function (validate, key, value, throws, props) {
         var action = throws ? validateStyle.throwErrors : validateStyle.emitErrors;
         var result = validate.call(validateStyle, util.extend({

--- a/js/symbol/sprite_atlas.js
+++ b/js/symbol/sprite_atlas.js
@@ -222,6 +222,12 @@ SpriteAtlas.prototype.bind = function(gl, linear) {
     }
 };
 
+SpriteAtlas.prototype.remove = function () {
+    // delete this.texture;
+    util.removeObjectProperties(this.images);
+    util.removeObjectProperties(this);
+};
+
 function AtlasImage(rect, width, height, sdf, pixelRatio) {
     this.rect = rect;
     this.width = width;

--- a/js/ui/map.js
+++ b/js/ui/map.js
@@ -1345,15 +1345,19 @@ util.extend(Map.prototype, /** @lends Map.prototype */{
     remove: function() {
         if (this._hash) this._hash.remove();
         browser.cancelFrame(this._frameId);
+        this.style.removeSources();
         this.setStyle(null);
+        this.quadrantFactory.remove();
         if (typeof window !== 'undefined') {
             window.removeEventListener('resize', this._onWindowResize, false);
         }
         var extension = this.painter.gl.getExtension('WEBGL_lose_context');
         if (extension) extension.loseContext();
+        this.painter.remove();
         removeNode(this._canvasContainer);
         removeNode(this._controlContainer);
         this._container.classList.remove('mapboxgl-map');
+        util.removeObjectProperties(this);
     },
 
     _rerender: function() {

--- a/js/util/util.js
+++ b/js/util/util.js
@@ -512,3 +512,11 @@ exports.isClosedPolygon = function(points) {
     // polygon simplification can produce polygons with zero area and more than 3 points
     return (Math.abs(exports.calculateSignedArea(points)) > 0.01);
 };
+
+exports.removeObjectProperties = function (object) {
+    Object.keys(object).forEach(function (property) {
+        if (object.hasOwnProperty(property)) {
+            delete object[property];
+        }
+    });
+};


### PR DESCRIPTION
This PR contains changes to reduce memory leak after a map instance removal.
- added line_atlas, sprite_atlas cleanup
- added painter cleanup
- added pointer_group, quadrant, quadrant_factory cleanup
- added image_sprite cleanup
- added style cleanup