### PR TITLE
 Add safety check in helper method to verify that given object exists

### DIFF
--- a/js/util/util.js
+++ b/js/util/util.js
@@ -514,9 +514,13 @@ exports.isClosedPolygon = function(points) {
 };
 
 exports.removeObjectProperties = function (object) {
-    Object.keys(object).forEach(function (property) {
-        if (object.hasOwnProperty(property)) {
-            delete object[property];
-        }
-    });
+    var objectKeys = object && Object.keys(object);
+
+    if (objectKeys) {
+        objectKeys.forEach(function (property) {
+            if (object.hasOwnProperty(property)) {
+                delete object[property];
+            }
+        });
+    }
 };


### PR DESCRIPTION
Safety check for issue with Object.keys method call on an undefined or null

```
Uncaught TypeError: Cannot convert undefined or null to object
    at Function.keys (<anonymous>)
```